### PR TITLE
tcb: fluent-bit: enable service and add uptime metric

### DIFF
--- a/tcb/customConfig/usr/etc/.tcattr
+++ b/tcb/customConfig/usr/etc/.tcattr
@@ -18,3 +18,24 @@ other::---
 user::rw-
 group::r--
 other::r--
+
+# file: fluent-bit/fluent-bit.conf
+# owner: 0
+# group: 0
+user::rwx
+group::r-x
+other::r-x
+
+# file: fluent-bit/enabled
+# owner: 0
+# group: 0
+user::rw-
+group::r--
+other::r--
+
+# file: systemd/system/multi-user.target.wants/remote-access.service
+# owner: 0
+# group: 0
+user::rw-
+group::r--
+other::r--

--- a/tcb/customConfig/usr/etc/fluent-bit/fluent-bit.conf
+++ b/tcb/customConfig/usr/etc/fluent-bit/fluent-bit.conf
@@ -1,0 +1,106 @@
+[SERVICE]
+    flush        1
+    daemon       Off
+    log_level    info
+    parsers_file parsers.conf
+    plugins_file plugins.conf
+
+[INPUT]
+    name          cpu
+    tag           cpu
+    interval_sec  300
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name       nest
+    Match      cpu
+    Operation  nest
+    Wildcard   *
+    Nest_under cpu
+
+[INPUT]
+    name          mem
+    tag           memory
+    interval_sec  300
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name       nest
+    Match      memory
+    Operation  nest
+    Wildcard   *
+    Nest_under memory
+
+[INPUT]
+    name          thermal
+    tag           temperature
+    name_regex    thermal_zone0
+    interval_sec  300
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name       nest
+    Match      temperature
+    Operation  nest
+    Wildcard   *
+    Nest_under temperature
+
+[INPUT]
+    name          proc
+    proc_name     dockerd
+    tag           proc_docker
+    fd            false
+    mem           false
+    interval_sec  300
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name       nest
+    Match      proc_docker
+    Operation  nest
+    Wildcard   *
+    Nest_under docker
+
+[INPUT]
+    Name          exec
+    Tag           emmc_health
+    Command       /usr/bin/emmc-health
+    Parser        json
+    Interval_Sec  300
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name       nest
+    Match      emmc_health
+    Operation  nest
+    Wildcard   *
+    Nest_under custom
+
+[INPUT]
+    Name          exec
+    Tag           uptime
+    Command       cut -d ' ' -f1 /proc/uptime | awk '{print "{\"uptime\":" $1 "}"}'
+    Parser        json
+    Interval_Sec  300
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name       nest
+    Match      uptime
+    Operation  nest
+    Wildcard   *
+    Nest_under custom
+
+[OUTPUT]
+    name         http
+    match        *
+    host         dgw.torizon.io
+    port         443
+    uri          monitoring/fluentbit-metrics
+    format       json
+    tls          on
+    tls.verify   off
+    tls.ca_file  /usr/lib/sota/root.crt
+    tls.key_file /var/sota/import/pkey.pem
+    tls.crt_file /var/sota/import/client.pem
+    Retry_Limit  10

--- a/tcb/customConfig/usr/etc/systemd/system/multi-user.target.wants/remote-access.service
+++ b/tcb/customConfig/usr/etc/systemd/system/multi-user.target.wants/remote-access.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/remote-access.service


### PR DESCRIPTION
Make it possible to identify unexpected reboots remotely by just looking at the uptime chart.

Fix #18